### PR TITLE
Reuse favorite document IDs when syncing from Firestore

### DIFF
--- a/WDWDaydreams/Services/FirebaseDataService.swift
+++ b/WDWDaydreams/Services/FirebaseDataService.swift
@@ -270,7 +270,8 @@ class FirebaseDataService {
             
             for doc in documents {
                 let data = doc.data()
-                
+                let storyID = UUID(uuidString: doc.documentID) ?? UUID()
+
                 // Extract basic data
                 guard let dateTimestamp = data["date"] as? Timestamp,
                       let itemsDict = data["items"] as? [String: String] else {
@@ -291,7 +292,7 @@ class FirebaseDataService {
                 
                 // Create DaydreamStory
                 let story = DaydreamStory(
-                    id: UUID(), // Generate new UUID
+                    id: storyID,
                     dateAssigned: dateTimestamp.dateValue(),
                     items: items,
                     assignedAuthor: author,


### PR DESCRIPTION
## Summary
- ensure fetched favorite stories reuse their Firestore document IDs when constructing DaydreamStory models
- fall back to a generated UUID only if the stored document ID is not a valid UUID string

## Testing
- not run (Firebase-connected tests require credentials)

------
https://chatgpt.com/codex/tasks/task_e_68d031c9f020832d852a8e8357bb4d13