### PR TITLE
Fix default author selection on error

### DIFF
--- a/WDWDaydreams/Services/FirebaseDataService.swift
+++ b/WDWDaydreams/Services/FirebaseDataService.swift
@@ -545,8 +545,8 @@ class FirebaseDataService {
             .getDocuments { snapshot, error in
                 if let error = error {
                     print("Error determining next author: \(error.localizedDescription)")
-                    // Default to alternating from user if there's an error
-                    completion(StoryAuthor.user == .user ? .wife : .user)
+                    // Default based on which user is signed in to keep turn order stable
+                    completion(self.isCurrentUserJon ? .user : .wife)
                     return
                 }
                 


### PR DESCRIPTION
## Summary
- update FirebaseDataService to choose a deterministic author when an error occurs while determining the next author

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d031d06b50832db11aa78968074d89