### PR TITLE
Add onboarding flow, feedback banner, and analytics hooks

### DIFF
--- a/WDWDaydreams/Models/UserProfile.swift
+++ b/WDWDaydreams/Models/UserProfile.swift
@@ -75,28 +75,31 @@ struct UserProfile: Codable, Identifiable {
 }
 
 struct UserPreferences: Codable {
-    let notifications: NotificationPreferences
-    let privacy: PrivacySettings
-    let storyCategories: [String]
-    let tripDate: Date?
+    var notifications: NotificationPreferences
+    var privacy: PrivacySettings
+    var storyCategories: [String]
+    var tripDate: Date?
+    var hasCompletedOnboarding: Bool
     
     var dictionary: [String: Any] {
         var dict: [String: Any] = [
             "notifications": notifications.dictionary,
             "privacy": privacy.dictionary,
-            "storyCategories": storyCategories
+            "storyCategories": storyCategories,
+            "hasCompletedOnboarding": hasCompletedOnboarding
         ]
         if let tripDate = tripDate {
             dict["tripDate"] = Timestamp(date: tripDate)
         }
         return dict
     }
-    
-    init(notifications: NotificationPreferences = NotificationPreferences(), privacy: PrivacySettings = PrivacySettings(), storyCategories: [String] = ["park", "ride", "food"], tripDate: Date? = nil) {
+
+    init(notifications: NotificationPreferences = NotificationPreferences(), privacy: PrivacySettings = PrivacySettings(), storyCategories: [String] = ["park", "ride", "food"], tripDate: Date? = nil, hasCompletedOnboarding: Bool = false) {
         self.notifications = notifications
         self.privacy = privacy
         self.storyCategories = storyCategories
         self.tripDate = tripDate
+        self.hasCompletedOnboarding = hasCompletedOnboarding
     }
     
     init?(dictionary: [String: Any]) {
@@ -106,11 +109,12 @@ struct UserPreferences: Codable {
               let notifications = NotificationPreferences(dictionary: notificationsData),
               let privacy = PrivacySettings(dictionary: privacyData)
         else { return nil }
-        
+
         self.notifications = notifications
         self.privacy = privacy
         self.storyCategories = storyCategories
-        
+        self.hasCompletedOnboarding = dictionary["hasCompletedOnboarding"] as? Bool ?? false
+
         if let tripDateTimestamp = dictionary["tripDate"] as? Timestamp {
             self.tripDate = tripDateTimestamp.dateValue()
         } else {

--- a/WDWDaydreams/Services/AnalyticsService.swift
+++ b/WDWDaydreams/Services/AnalyticsService.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+#if canImport(FirebaseAnalytics)
+import FirebaseAnalytics
+#endif
+
+#if canImport(FirebaseCrashlytics)
+import FirebaseCrashlytics
+#endif
+
+enum AnalyticsEvent: String {
+    case onboardingCompleted = "onboarding_completed"
+    case login = "login_success"
+    case logout = "logout"
+    case accountDeleted = "account_deleted"
+}
+
+final class AnalyticsService {
+    static let shared = AnalyticsService()
+
+    func log(_ event: AnalyticsEvent, parameters: [String: Any]? = nil) {
+        #if canImport(FirebaseAnalytics)
+        Analytics.logEvent(event.rawValue, parameters: parameters)
+        #else
+        print("[Analytics] \(event.rawValue): \(parameters ?? [:])")
+        #endif
+    }
+
+    func record(error: Error) {
+        #if canImport(FirebaseCrashlytics)
+        Crashlytics.crashlytics().record(error: error)
+        #else
+        print("[Crashlytics] \(error.localizedDescription)")
+        #endif
+    }
+}

--- a/WDWDaydreams/Services/UIFeedbackCenter.swift
+++ b/WDWDaydreams/Services/UIFeedbackCenter.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftUI
+
+enum FeedbackStyle {
+    case info
+    case success
+    case warning
+    case error
+
+    var color: Color {
+        switch self {
+        case .info: return .blue
+        case .success: return .green
+        case .warning: return .orange
+        case .error: return .red
+        }
+    }
+}
+
+struct FeedbackBanner: Identifiable {
+    let id = UUID()
+    let message: String
+    let style: FeedbackStyle
+}
+
+final class UIFeedbackCenter: ObservableObject {
+    @Published var currentBanner: FeedbackBanner?
+
+    func present(message: String, style: FeedbackStyle = .info) {
+        DispatchQueue.main.async {
+            self.currentBanner = FeedbackBanner(message: message, style: style)
+        }
+    }
+}
+
+struct FeedbackBannerView: View {
+    @Binding var banner: FeedbackBanner?
+
+    var body: some View {
+        VStack {
+            Spacer()
+            if let currentBanner = banner {
+                Text(currentBanner.message)
+                    .font(.subheadline)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(currentBanner.style.color.opacity(0.9))
+                    .foregroundColor(.white)
+                    .cornerRadius(12)
+                    .padding()
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            withAnimation {
+                                self.banner = nil
+                            }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut, value: banner)
+    }
+}

--- a/WDWDaydreams/Views/ContentView.swift
+++ b/WDWDaydreams/Views/ContentView.swift
@@ -6,12 +6,12 @@ struct ContentView: View {
     @EnvironmentObject var weatherManager: WDWWeatherManager
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var themeManager: ThemeManager
+    @EnvironmentObject var feedbackCenter: UIFeedbackCenter
     
     @State private var showSettings = false
     @State private var currentView = "Today"
     @State private var isInitializing = true
     @State private var showLogoutAlert = false
-    @State private var errorMessage = ""
 
     // Optimized theme computation - only changes when theme selection changes
     @State private var currentTheme: Theme = LightTheme()
@@ -115,9 +115,7 @@ struct ContentView: View {
             if isInitializing {
                 LoadingOverlayView(theme: currentTheme)
             }
-            if !errorMessage.isEmpty {
-                ErrorToastView(message: $errorMessage, theme: currentTheme)
-            }
+            FeedbackBannerView(banner: $feedbackCenter.currentBanner)
         }
         .preferredColorScheme(
             themeManager.selectedTheme == .light ? .light :
@@ -133,7 +131,7 @@ struct ContentView: View {
         }
         .onReceive(authViewModel.$errorMessage) { msg in
             if !msg.isEmpty {
-                errorMessage = msg
+                feedbackCenter.present(message: msg, style: .error)
                 authViewModel.errorMessage = ""
             }
         }

--- a/WDWDaydreams/Views/OnboardingView.swift
+++ b/WDWDaydreams/Views/OnboardingView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var themeManager: ThemeManager
+    @EnvironmentObject var feedbackCenter: UIFeedbackCenter
+    @State private var preferences: UserPreferences = UserPreferences()
+    @State private var isRequestingNotifications = false
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Stay in the loop")) {
+                    Toggle("Story reminders", isOn: binding(for: \.notifications.storyReminders))
+                    Toggle("Connection requests", isOn: binding(for: \.notifications.connectionRequests))
+                    Toggle("New story alerts", isOn: binding(for: \.notifications.newStoryNotifications))
+                    Toggle("Weekly digest", isOn: binding(for: \.notifications.weeklyDigest))
+                    Button(action: requestNotifications) {
+                        HStack {
+                            if isRequestingNotifications { ProgressView() }
+                            Text("Allow Notifications")
+                        }
+                    }
+                }
+
+                Section(header: Text("Privacy")) {
+                    Picker("Profile visibility", selection: binding(for: \.privacy.profileVisibility)) {
+                        ForEach(ProfileVisibility.allCases, id: \.self) { option in
+                            Text(option.displayName).tag(option)
+                        }
+                    }
+                    Toggle("Allow story sharing", isOn: binding(for: \.privacy.allowStorySharing))
+                    Toggle("Allow discovery", isOn: binding(for: \.privacy.allowConnectionDiscovery))
+                }
+
+                Section(header: Text("Prompt categories")) {
+                    ForEach(Category.allCases) { category in
+                        Toggle(category.rawValue.capitalized, isOn: Binding(
+                            get: { preferences.storyCategories.contains(category.rawValue) },
+                            set: { newValue in
+                                if newValue {
+                                    if !preferences.storyCategories.contains(category.rawValue) {
+                                        preferences.storyCategories.append(category.rawValue)
+                                    }
+                                } else {
+                                    preferences.storyCategories.removeAll { $0 == category.rawValue }
+                                }
+                            }
+                        ))
+                    }
+                }
+
+                Section(header: Text("Trip planning")) {
+                    DatePicker("Next visit", selection: Binding(
+                        get: { preferences.tripDate ?? Date() },
+                        set: { preferences.tripDate = $0 }
+                    ), displayedComponents: .date)
+                }
+
+                Section {
+                    Button(action: savePreferences) {
+                        HStack {
+                            if isSaving { ProgressView() }
+                            Text("Finish onboarding")
+                        }
+                    }
+                    .disabled(isSaving)
+                }
+            }
+            .navigationTitle("Welcome")
+        }
+        .onAppear {
+            if let profile = authViewModel.userProfile {
+                preferences = profile.preferences
+            }
+        }
+    }
+
+    private func binding<Value>(for keyPath: WritableKeyPath<UserPreferences, Value>) -> Binding<Value> {
+        Binding(
+            get: { preferences[keyPath: keyPath] },
+            set: { preferences[keyPath: keyPath] = $0 }
+        )
+    }
+
+    private func requestNotifications() {
+        isRequestingNotifications = true
+        NotificationManager.shared.requestPermission()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            isRequestingNotifications = false
+            feedbackCenter.present(message: "Notification request sent", style: .info)
+        }
+    }
+
+    private func savePreferences() {
+        isSaving = true
+        Task {
+            await authViewModel.completeOnboarding(preferences: preferences)
+            feedbackCenter.present(message: "Preferences saved", style: .success)
+            isSaving = false
+        }
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .environmentObject(AuthViewModel())
+        .environmentObject(ThemeManager())
+        .environmentObject(UIFeedbackCenter())
+}

--- a/WDWDaydreams/Views/SettingsView.swift
+++ b/WDWDaydreams/Views/SettingsView.swift
@@ -4,11 +4,15 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var manager: ScenarioManager
     @EnvironmentObject var themeManager: ThemeManager
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var feedbackCenter: UIFeedbackCenter
     @Environment(\.theme) var theme: Theme
     @Environment(\.dismiss) private var dismiss
-    
+
     @State private var showClearConfirmation = false
     @State private var testResults: String = ""
+    @State private var preferences: UserPreferences = UserPreferences()
+    @State private var showingSupport = false
     
     // Computed properties to replace ViewModel
     private var enabledCategories: Binding<[Category]> {
@@ -73,6 +77,85 @@ struct SettingsView: View {
                     }
                     .listRowBackground(theme.cardBackground)
 
+                    // Notification Preferences
+                    Section(header: SectionHeader(title: "Notifications", theme: theme)) {
+                        Toggle("Story reminders", isOn: Binding(
+                            get: { preferences.notifications.storyReminders },
+                            set: { preferences.notifications = NotificationPreferences(
+                                storyReminders: $0,
+                                connectionRequests: preferences.notifications.connectionRequests,
+                                newStoryNotifications: preferences.notifications.newStoryNotifications,
+                                weeklyDigest: preferences.notifications.weeklyDigest
+                            ) }
+                        ))
+                        Toggle("Connection requests", isOn: Binding(
+                            get: { preferences.notifications.connectionRequests },
+                            set: { preferences.notifications = NotificationPreferences(
+                                storyReminders: preferences.notifications.storyReminders,
+                                connectionRequests: $0,
+                                newStoryNotifications: preferences.notifications.newStoryNotifications,
+                                weeklyDigest: preferences.notifications.weeklyDigest
+                            ) }
+                        ))
+                        Toggle("New story alerts", isOn: Binding(
+                            get: { preferences.notifications.newStoryNotifications },
+                            set: { preferences.notifications = NotificationPreferences(
+                                storyReminders: preferences.notifications.storyReminders,
+                                connectionRequests: preferences.notifications.connectionRequests,
+                                newStoryNotifications: $0,
+                                weeklyDigest: preferences.notifications.weeklyDigest
+                            ) }
+                        ))
+                        Toggle("Weekly digest", isOn: Binding(
+                            get: { preferences.notifications.weeklyDigest },
+                            set: { preferences.notifications = NotificationPreferences(
+                                storyReminders: preferences.notifications.storyReminders,
+                                connectionRequests: preferences.notifications.connectionRequests,
+                                newStoryNotifications: preferences.notifications.newStoryNotifications,
+                                weeklyDigest: $0
+                            ) }
+                        ))
+                        Button("Request Notification Permission") {
+                            NotificationManager.shared.requestPermission()
+                            feedbackCenter.present(message: "Notification permission requested", style: .info)
+                        }
+                        .buttonStyle(DisneyButtonStyle(color: theme.magicBlue))
+                    }
+                    .listRowBackground(theme.cardBackground)
+
+                    // Privacy
+                    Section(header: SectionHeader(title: "Privacy & Permissions", theme: theme)) {
+                        Picker("Profile visibility", selection: Binding(
+                            get: { preferences.privacy.profileVisibility },
+                            set: { preferences.privacy = PrivacySettings(
+                                profileVisibility: $0,
+                                allowStorySharing: preferences.privacy.allowStorySharing,
+                                allowConnectionDiscovery: preferences.privacy.allowConnectionDiscovery
+                            ) }
+                        )) {
+                            ForEach(ProfileVisibility.allCases, id: \.self) { visibility in
+                                Text(visibility.displayName).tag(visibility)
+                            }
+                        }
+                        Toggle("Allow Story Sharing", isOn: Binding(
+                            get: { preferences.privacy.allowStorySharing },
+                            set: { preferences.privacy = PrivacySettings(
+                                profileVisibility: preferences.privacy.profileVisibility,
+                                allowStorySharing: $0,
+                                allowConnectionDiscovery: preferences.privacy.allowConnectionDiscovery
+                            ) }
+                        ))
+                        Toggle("Allow Discovery", isOn: Binding(
+                            get: { preferences.privacy.allowConnectionDiscovery },
+                            set: { preferences.privacy = PrivacySettings(
+                                profileVisibility: preferences.privacy.profileVisibility,
+                                allowStorySharing: preferences.privacy.allowStorySharing,
+                                allowConnectionDiscovery: $0
+                            ) }
+                        ))
+                    }
+                    .listRowBackground(theme.cardBackground)
+
                     // Category Section
                     Section(header: SectionHeader(title: "Enable Categories For Prompts", theme: theme)) {
                         ForEach(Category.allCases) { category in
@@ -133,6 +216,25 @@ struct SettingsView: View {
                     }
                     .listRowBackground(theme.cardBackground)
 
+                    Section(header: SectionHeader(title: "Account & Support", theme: theme)) {
+                        Button("Save Preferences") {
+                            Task {
+                                await authViewModel.updatePreferences(preferences)
+                                feedbackCenter.present(message: "Preferences saved", style: .success)
+                            }
+                        }
+                        .buttonStyle(DisneyButtonStyle(color: theme.magicBlue))
+
+                        Button("Delete Account", role: .destructive) {
+                            Task { await authViewModel.deleteAccount() }
+                        }
+
+                        Button("Help & Support") {
+                            showingSupport = true
+                        }
+                    }
+                    .listRowBackground(theme.cardBackground)
+
                     // Danger Zone Section
                     Section(header: Text("Danger Zone").foregroundColor(theme.mickeyRed).font(.headline)) {
                         Button(action: {
@@ -175,6 +277,13 @@ struct SettingsView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .sheet(isPresented: $showingSupport) {
+            SupportView()
+                .environment(\.theme, theme)
+        }
+        .onAppear {
+            preferences = authViewModel.userProfile?.preferences ?? UserPreferences(hasCompletedOnboarding: true)
+        }
     }
     
     // Local helper functions to replace ViewModel methods

--- a/WDWDaydreams/Views/SupportView.swift
+++ b/WDWDaydreams/Views/SupportView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct SupportView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) var theme: Theme
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section(header: Text("FAQ")) {
+                    Text("How do I reset my password?")
+                    Text("How do I pair with a partner?")
+                    Text("How is my data used?")
+                }
+
+                Section(header: Text("Contact")) {
+                    Link("Email support", destination: URL(string: "mailto:support@wdwdaydreams.example")!)
+                    Link("View privacy policy", destination: URL(string: "https://example.com/privacy")!)
+                }
+            }
+            .listStyle(InsetGroupedListStyle())
+            .navigationTitle("Help & Support")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(theme.magicBlue)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SupportView()
+        .environment(\.theme, LightTheme())
+}

--- a/WDWDaydreams/WDWDaydreamsApp.swift
+++ b/WDWDaydreams/WDWDaydreamsApp.swift
@@ -25,6 +25,7 @@ struct WDWDaydreamsApp: App {
     @StateObject var weatherManager = WDWWeatherManager()
     @StateObject var themeManager = ThemeManager()
     @StateObject var fcmService = FCMService.shared
+    @StateObject var feedbackCenter = UIFeedbackCenter()
     let notificationManager = NotificationManager.shared
     
     // Create a UIApplicationDelegateAdaptor for handling push notifications
@@ -88,6 +89,7 @@ struct WDWDaydreamsApp: App {
                 .environmentObject(weatherManager)
                 .environmentObject(themeManager)
                 .environmentObject(fcmService)
+                .environmentObject(feedbackCenter)
                 .onOpenURL { url in
                     GIDSignIn.sharedInstance.handle(url)
                 }
@@ -105,7 +107,12 @@ struct MainAppView: View {
     var body: some View {
         Group {
             if authViewModel.isAuthenticated {
-                AuthenticatedView()
+                if authViewModel.requiresOnboarding {
+                    OnboardingView()
+                        .environmentObject(authViewModel)
+                } else {
+                    AuthenticatedView()
+                }
             } else {
                 LoginView()
             }

--- a/WDWDaydreamsUITests/OnboardingUITests.swift
+++ b/WDWDaydreamsUITests/OnboardingUITests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+final class OnboardingUITests: XCTestCase {
+
+    func testLoginScreenDisplaysAuthOptions() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.buttons["Continue with Apple"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Continue with Google"].exists)
+        XCTAssertTrue(app.buttons["Forgot Password?"].exists)
+    }
+}


### PR DESCRIPTION
## Summary
- add onboarding flow for capturing notification, privacy, and category preferences and gating first-run
- introduce centralized feedback banner plus support view and expanded settings for privacy, notifications, and account actions
- add analytics/crash logging hooks and UI test coverage for login options

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932efd55230832d818627841d355de3)